### PR TITLE
Use byte slices instead of strings

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -7,13 +7,13 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/cloudflare/migp-go/pkg/migp"
 )
@@ -83,7 +83,7 @@ func main() {
 
 	scanner := bufio.NewScanner(inputFile)
 	for scanner.Scan() {
-		fields := strings.SplitN(scanner.Text(), ":", 2)
+		fields := bytes.SplitN(scanner.Bytes(), []byte(":"), 2)
 		if len(fields) < 2 {
 			continue
 		}
@@ -94,7 +94,7 @@ func main() {
 		} else {
 
 			if !showPassword {
-				password = ""
+				password = nil
 			}
 			out, err := json.Marshal(struct {
 				Username string `json:"username"`
@@ -102,8 +102,8 @@ func main() {
 				Status   string `json:"status"`
 				Metadata string `json:"metadata,omitempty"`
 			}{
-				Username: username,
-				Password: password,
+				Username: string(username),
+				Password: string(password),
 				Status:   status.String(),
 				Metadata: string(metadata),
 			})

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,12 +9,12 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"flag"
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/cloudflare/migp-go/pkg/migp"
 )
@@ -78,13 +78,13 @@ func main() {
 	log.Printf("Encrypting breach entries: %d successes, %d failures", successCount, failureCount)
 	scanner := bufio.NewScanner(inputFile)
 	for scanner.Scan() {
-		fields := strings.SplitN(scanner.Text(), ":", 2)
+		fields := bytes.SplitN(scanner.Bytes(), []byte(":"), 2)
 		if len(fields) < 2 {
 			failureCount += 1
 			continue
 		}
 		username, password := fields[0], fields[1]
-		if err := s.insert(username, password, metadata, numVariants, includeUsernameVariant); err != nil {
+		if err := s.insert(username, password, []byte(metadata), numVariants, includeUsernameVariant); err != nil {
 			failureCount += 1
 			continue
 		}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -48,10 +48,10 @@ func (s *server) handler() http.Handler {
 }
 
 // insert encrypts a credential pair and stores it in the configured KV store
-func (s *server) insert(username, password, metadata string, numVariants int, includeUsernameVariant bool) error {
+func (s *server) insert(username, password, metadata []byte, numVariants int, includeUsernameVariant bool) error {
 
 	bucketIDHex := migp.BucketIDToHex(s.migpServer.BucketID(username))
-	newEntry, err := s.migpServer.EncryptBucketEntry(username, password, migp.MetadataBreachedPassword, []byte(metadata))
+	newEntry, err := s.migpServer.EncryptBucketEntry(username, password, migp.MetadataBreachedPassword, metadata)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (s *server) insert(username, password, metadata string, numVariants int, in
 
 	passwordVariants := mutator.NewRDasMutator().Mutate(password, numVariants)
 	for _, variant := range passwordVariants {
-		newEntry, err = s.migpServer.EncryptBucketEntry(username, variant, migp.MetadataSimilarPassword, []byte(metadata))
+		newEntry, err = s.migpServer.EncryptBucketEntry(username, variant, migp.MetadataSimilarPassword, metadata)
 		if err != nil {
 			return err
 		}
@@ -73,7 +73,7 @@ func (s *server) insert(username, password, metadata string, numVariants int, in
 	}
 
 	if includeUsernameVariant {
-		newEntry, err = s.migpServer.EncryptBucketEntry(username, "", migp.MetadataBreachedUsername, []byte(metadata))
+		newEntry, err = s.migpServer.EncryptBucketEntry(username, nil, migp.MetadataBreachedUsername, metadata)
 		if err != nil {
 			return err
 		}

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"net/http/httptest"
 	"testing"
 
@@ -13,9 +14,9 @@ import (
 // TestServer spins up a MIGP server and runs a series of tests
 func TestServer(t *testing.T) {
 
-	testUsername := "username1"
-	testPassword := "password1"
-	testMetadata := "test metadata"
+	testUsername := []byte("username1")
+	testPassword := []byte("password1")
+	testMetadata := []byte("test metadata")
 
 	s, err := newServer(migp.DefaultServerConfig())
 	if err != nil {
@@ -34,8 +35,8 @@ func TestServer(t *testing.T) {
 	if status != migp.NotInBreach {
 		t.Fatalf("status: want %s, got %s", migp.NotInBreach, status)
 	}
-	if string(metadata) != "" {
-		t.Fatalf("metadata: want %s, got %s", "", string(metadata))
+	if len(metadata) != 0 {
+		t.Fatalf("metadata: want %d, got %d", 0, len(metadata))
 	}
 
 	// insert test record
@@ -52,7 +53,7 @@ func TestServer(t *testing.T) {
 	if status != migp.InBreach {
 		t.Fatalf("status: want %s, got %s", migp.InBreach, status)
 	}
-	if string(metadata) != testMetadata {
+	if !bytes.Equal(metadata, testMetadata) {
 		t.Fatalf("metadata: want %s, got %s", testMetadata, string(metadata))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/cloudflare/circl v1.1.1-0.20211202201456-cd788e30354b
+	github.com/spaolacci/murmur3 v1.1.0
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/bwesterb/go-ristretto v1.2.1 h1:Xd9ZXmjKE2aY8Ub7+4bX7tXsIPsV1pIZaUlJU
 github.com/bwesterb/go-ristretto v1.2.1/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cloudflare/circl v1.1.1-0.20211202201456-cd788e30354b h1:f8CvSOYFhVYCKjR0IJSV+HJruJ+tjl+B6Bw67I813wI=
 github.com/cloudflare/circl v1.1.1-0.20211202201456-cd788e30354b/go.mod h1:2pFYgkRokjMOqffpY0D1CU6vx0Q5PRPsFYknPwCPrt8=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSEmmlyVS4kxBNkeA9tLJiTI=
 golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/pkg/migp/client_test.go
+++ b/pkg/migp/client_test.go
@@ -23,19 +23,19 @@ func (kv *KVMock) Get(key string) ([]byte, error) {
 func TestQuery(t *testing.T) {
 
 	testCases := []struct {
-		Username     string
-		Password     string
+		Username     []byte
+		Password     []byte
 		MetadataFlag MetadataType
 		Metadata     []byte
 		OutputValue  BreachStatus
 	}{
-		{"test@mail.com", "password1234", MetadataBreachedPassword, []byte("my favorite breach"), InBreach},
-		{"TESTt@mail.com", "password1234", MetadataBreachedPassword, []byte("my favorite breach"), InBreach},
-		{"test@mail.com", "password3214", MetadataBreachedPassword, []byte("my favorite breach, flipped"), InBreach},
-		{"", "", MetadataSimilarPassword, []byte("my favorite breach"), SimilarInBreach},
-		{"!!#%test", "Password1231", MetadataSimilarPassword, nil, SimilarInBreach},
-		{"test2", "!!&*F(DSbjklzd", MetadataBreachedPassword, []byte("$#!!%BVAF"), InBreach},
-		{"username", "password5678", MetadataBreachedUsername, []byte("my favorite breach"), UsernameInBreach},
+		{[]byte("test@mail.com"), []byte("password1234"), MetadataBreachedPassword, []byte("my favorite breach"), InBreach},
+		{[]byte("TESTt@mail.com"), []byte("password1234"), MetadataBreachedPassword, []byte("my favorite breach"), InBreach},
+		{[]byte("test@mail.com"), []byte("password3214"), MetadataBreachedPassword, []byte("my favorite breach, flipped"), InBreach},
+		{[]byte{}, []byte{}, MetadataSimilarPassword, []byte("my favorite breach"), SimilarInBreach},
+		{[]byte("!!#%test"), []byte("Password1231"), MetadataSimilarPassword, nil, SimilarInBreach},
+		{[]byte("test2"), []byte("!!&*F(DSbjklzd"), MetadataBreachedPassword, []byte("$#!!%BVAF"), InBreach},
+		{[]byte("username"), []byte("password5678"), MetadataBreachedUsername, []byte("my favorite breach"), UsernameInBreach},
 	}
 
 	// initialize server with fresh random key
@@ -88,7 +88,7 @@ func TestQuery(t *testing.T) {
 	}
 
 	// test for an uninserted entry
-	username, password := "username", "password"
+	username, password := []byte("username"), []byte("password")
 	request, clientFinalize, err := client.Request(username, password)
 	if err != nil {
 		t.Error(err)

--- a/pkg/migp/common_test.go
+++ b/pkg/migp/common_test.go
@@ -1,0 +1,59 @@
+package migp
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSerializeUsernamePassword(t *testing.T) {
+	tests := []struct {
+		inUser []byte
+		inPass []byte
+		out    []byte
+	}{
+		{nil, nil, []byte{0, 0, 0, 0}},
+		{[]byte{1, 2, 3}, []byte{4, 5, 6, 7}, []byte{0, 3, 1, 2, 3, 0, 4, 4, 5, 6, 7}},
+	}
+	for i, test := range tests {
+		result := serializeUsernamePassword(test.inUser, test.inPass)
+		if !bytes.Equal(result, test.out) {
+			t.Errorf("failed test %d: want %v, got %v", i, test.out, result)
+		}
+	}
+}
+
+func TestBucketHashToID(t *testing.T) {
+	tests := []struct {
+		hash    []byte
+		bitSize int
+		out     uint32
+	}{
+		{[]byte{1, 2, 3, 4, 5, 6}, 0, 0},
+		{[]byte{1, 2, 3, 4, 5, 6}, 15, 0x81},
+		{[]byte{1, 2, 3, 4, 5, 6}, 16, 0x102},
+		{[]byte{1, 2, 3, 4, 5, 6}, 32, 0x1020304},
+	}
+	for i, test := range tests {
+		result := bucketHashToID(test.hash, test.bitSize)
+		if result != test.out {
+			t.Errorf("failed test %d: want %d, got %d", i, test.out, result)
+		}
+	}
+}
+
+func TestBucketIDToHex(t *testing.T) {
+	tests := []struct {
+		in  uint32
+		out string
+	}{
+		{0x01020304, "01020304"},
+		{0xff, "000000ff"},
+		{0xffffffff, "ffffffff"},
+	}
+	for i, test := range tests {
+		result := BucketIDToHex(test.in)
+		if result != test.out {
+			t.Errorf("failed test %d: want %q, got %q", i, test.out, result)
+		}
+	}
+}

--- a/pkg/migp/server.go
+++ b/pkg/migp/server.go
@@ -135,21 +135,21 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 }
 
 // deriveBucketEntryKey derives a bucket entry key from a credential pair
-func (s *Server) deriveBucketEntryKey(username string, password string) ([]byte, error) {
-	input := s.slowHasher.Hash(serializeUserPassword(username, password))
+func (s *Server) deriveBucketEntryKey(username []byte, password []byte) ([]byte, error) {
+	input := s.slowHasher.Hash(serializeUsernamePassword(username, password))
 	return s.oprfServer.FullEvaluate(input, OprfInfo)
 }
 
 // BucketID returns the bucket ID for the given username
-func (s *Server) BucketID(username string) uint32 {
-	return bucketHashToID(s.bucketHasher.Hash([]byte(username)), s.bucketIDBitSize)
+func (s *Server) BucketID(username []byte) uint32 {
+	return bucketHashToID(s.bucketHasher.Hash(username), s.bucketIDBitSize)
 }
 
 // EncryptBucketEntry performs the full OPRF and encryption of metadata, without any
 // blinding steps. This is useful for precomputing the buckets of encrypted
 // items. The return value is the bucket ID (2 byte hash of username) as well
 // as the ciphertext, both encoded as byte slices.
-func (s *Server) EncryptBucketEntry(username string, password string, metadataFlag MetadataType, metadata []byte) ([]byte, error) {
+func (s *Server) EncryptBucketEntry(username, password []byte, metadataFlag MetadataType, metadata []byte) ([]byte, error) {
 	if !metadataFlag.Valid() {
 		return nil, errors.New("invalid metadata flag value: " + string(metadataFlag))
 	}

--- a/pkg/migp/server_test.go
+++ b/pkg/migp/server_test.go
@@ -16,6 +16,10 @@ import (
 // serialized and deserialized
 func TestSerialization(t *testing.T) {
 
+	testUsername := []byte("username1")
+	testPassword := []byte("password1")
+	testMetadata := []byte("test metadata")
+
 	// initialize server with fresh random key
 	server, err := NewServer(DefaultServerConfig())
 	if err != nil {
@@ -40,12 +44,12 @@ func TestSerialization(t *testing.T) {
 		t.Error("serialization failed: version not equal")
 	}
 
-	ciphertextA, err := server.EncryptBucketEntry("testuser", "testpassword", MetadataSimilarPassword, []byte("helloworld"))
+	ciphertextA, err := server.EncryptBucketEntry(testUsername, testPassword, MetadataSimilarPassword, testMetadata)
 	if err != nil {
 		t.Error(err)
 	}
 
-	ciphertextB, err := server2.EncryptBucketEntry("testuser", "testpassword", MetadataSimilarPassword, []byte("helloworld"))
+	ciphertextB, err := server2.EncryptBucketEntry(testUsername, testPassword, MetadataSimilarPassword, testMetadata)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/mutator/mutator.go
+++ b/pkg/mutator/mutator.go
@@ -6,5 +6,5 @@ package mutator
 // Mutator interface gives a Mutate() function that takes as input a requested
 // number of mutations, and returns a set of mutated passwords
 type Mutator interface {
-	Mutate(string, int) []string
+	Mutate([]byte, int) [][]byte
 }

--- a/pkg/mutator/rdasmutator_test.go
+++ b/pkg/mutator/rdasmutator_test.go
@@ -4,18 +4,19 @@
 package mutator
 
 import (
+	"bytes"
 	"testing"
 )
 
 // TestRdasMutate tests that the mutator produces the expected variants
 func TestRdasMutate(t *testing.T) {
 	tests := []struct {
-		inPw   string
-		outPws []string
+		inPw   []byte
+		outPws [][]byte
 	}{
-		{inPw: "hello", outPws: []string{"Hello", "13hello", "hello1", "777hello", "helloN"}},
-		{inPw: "asdf1234asdf", outPws: []string{"zxcv1234zxcv", "asdf1234asdf1", "asdf1234a", "asdf1234as", "Asdf1234asdf", "asdf1234asdfN"}},
-		{inPw: "", outPws: []string{"1", "13", "777", "N"}},
+		{inPw: []byte("hello"), outPws: [][]byte{[]byte("Hello"), []byte("13hello"), []byte("hello1"), []byte("777hello"), []byte("helloN")}},
+		{inPw: []byte("asdf1234asdf"), outPws: [][]byte{[]byte("zxcv1234zxcv"), []byte("asdf1234asdf1"), []byte("asdf1234a"), []byte("asdf1234as"), []byte("Asdf1234asdf"), []byte("asdf1234asdfN")}},
+		{inPw: nil, outPws: [][]byte{[]byte("1"), []byte("13"), []byte("777"), []byte("N")}},
 	}
 
 	for _, test := range tests {
@@ -23,12 +24,12 @@ func TestRdasMutate(t *testing.T) {
 		variants := mutator.Mutate(test.inPw, 1000)
 		if len(variants) < 100 {
 			t.Errorf("RDasMutator didn't give back at least 100 variants, %s got only: %v",
-				test.inPw, variants)
+				test.inPw, len(variants))
 		}
 		for _, outPw := range test.outPws {
 			found := false
 			for _, variant := range variants {
-				if outPw == variant {
+				if bytes.Equal(outPw, variant) {
 					found = true
 					break
 				}
@@ -44,7 +45,7 @@ func TestRdasMutate(t *testing.T) {
 // BenchmarkRdasMutator100 benchmarks the first 100 mutator rules
 func BenchmarkRdasMutator100(b *testing.B) {
 	m := NewRDasMutator()
-	testPassword := "password1"
+	testPassword := []byte("password1")
 	for i := 0; i < b.N; i++ {
 		_ = m.Mutate(testPassword, 100)
 	}
@@ -53,7 +54,7 @@ func BenchmarkRdasMutator100(b *testing.B) {
 // BenchmarkRdasMutator10 benchmarks the first 10 mutator rules
 func BenchmarkRdasMutator10(b *testing.B) {
 	m := NewRDasMutator()
-	testPassword := "password1"
+	testPassword := []byte("password1")
 	for i := 0; i < b.N; i++ {
 		_ = m.Mutate(testPassword, 10)
 	}


### PR DESCRIPTION
Use byte slices instead of strings where applicable to reduce the amount
of type casting. The BenchmarkRdasMutator100 benchmark test shows a ~30%
reduction in ns/op and 43% reduction in B/op with these changes.

Add unit tests for utility functions in common_test.go.